### PR TITLE
Delete Flowfuse instance (decommisioned)

### DIFF
--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -105,13 +105,6 @@ sites:
     assignees:
       - gmolto
 
-  # Flowfuse AI4EOSC
-  - name: Flowfuse AI4EOSC - Provider UPV/GRyCAP
-    url: https://forge.flows.dev.ai4eosc.eu
-    icon: https://raw.githubusercontent.com/ai4eosc/status/master/static/logo-flowfuse.png
-    assignees:
-      - dieagra
-
   # PAPI
   - name: Platform API
     url: https://api.cloud.ai4eosc.eu


### PR DESCRIPTION
Flowfuse instance has been decommisioned. Now, you can deploy your own Node-RED instances directly from OSCAR.