### PR TITLE
update: use globalping for UPV/GRyCAP provider

### DIFF
--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -117,6 +117,8 @@ sites:
   - name: MinIO object storage - Provider UPV/GRyCAP
     url: https://console-minio-inference.cloud.ai4eosc.eu
     icon: https://raw.githubusercontent.com/ai4eosc/status/master/static/logo-minio.png
+    type: globalping
+    location: Western Europe
     assignees:
       - gmolto
       - SergioLangaritaBenitez
@@ -125,6 +127,8 @@ sites:
   - name: OSCAR - Provider UPV/GRyCAP
     url: https://inference.cloud.ai4eosc.eu
     icon: https://raw.githubusercontent.com/ai4eosc/status/master/static/logo-oscar.jpeg
+    type: globalping
+    location: Western Europe
     assignees:
       - gmolto
       - SergioLangaritaBenitez


### PR DESCRIPTION
## Monitoring configuration improvements for UPV/GRyCAP

### Changes

Updated the monitoring configuration for UPV/GRyCAP:

* Added `type: globalping` and `location: Western Europe` to **MinIO object storage - Provider UPV/GRyCAP**.
* Added `type: globalping` and `location: Western Europe` to **OSCAR - Provider UPV/GRyCAP**.

### Why

These changes help avoid false-positive downtime alerts when the cluster is actually running.

This issue was seen in recent reports:

* https://github.com/AI4EOSC/status/issues/1367
* https://github.com/AI4EOSC/status/issues/1366
* https://github.com/AI4EOSC/status/issues/1365

The same configuration was tested in the [GRyCAP monitoring service](https://github.com/grycap/status) and worked correctly, with zero false-positive alerts.
